### PR TITLE
fix(vectorstore): align sqlite-vec threshold fast path

### DIFF
--- a/internal/vectorstore/sqlite_vec_service.go
+++ b/internal/vectorstore/sqlite_vec_service.go
@@ -359,14 +359,14 @@ func (service *sqliteVecService) SearchByThreshold(request ThresholdSearchReques
 	}
 
 	var candidates []SearchResult
-	if service.extensionLoaded && metric == DistanceMetricL2 {
+	if service.extensionLoaded && store.OutputDimension > 0 && metric == DistanceMetricL2 {
 		candidates, err = service.searchWithSQLiteVec(store, SearchRequest{
 			StoreKind:  request.StoreKind,
 			Query:      request.Query,
 			Limit:      maxResults,
 			Metric:     metric,
 			ExternalID: request.ExternalID,
-		}, metric)
+		})
 	} else {
 		candidates, err = service.searchFallback(store, SearchRequest{
 			StoreKind:  request.StoreKind,
@@ -632,19 +632,11 @@ func (service *sqliteVecService) loadProfileStoreDefinition(kind StoreKind) (pro
 }
 
 func (service *sqliteVecService) searchWithSQLiteVec(store profileStoreDefinition, request SearchRequest) ([]SearchResult, error) {
-	queryJSON, err := encodeEmbeddingJSON(request.Query)
+	query, args, err := buildSQLiteVecSearchQuery(store, request)
 	if err != nil {
 		return nil, err
 	}
-	query := fmt.Sprintf(`
-		select m.external_id, m.metadata_json, v.distance
-		from %s as v
-		join %s as m on m.rowid = v.rowid
-		where embedding match ?
-		order by distance
-		limit ?
-	`, quoteSQLiteIdentifier(store.VectorTableName), quoteSQLiteIdentifier(store.MetadataTable))
-	rows, err := service.db.Query(query, queryJSON, request.Limit)
+	rows, err := service.db.Query(query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("search sqlite-vec virtual table: %w", err)
 	}
@@ -662,6 +654,27 @@ func (service *sqliteVecService) searchWithSQLiteVec(store profileStoreDefinitio
 		return nil, fmt.Errorf("iterate sqlite-vec search results: %w", err)
 	}
 	return results, nil
+}
+
+func buildSQLiteVecSearchQuery(store profileStoreDefinition, request SearchRequest) (string, []any, error) {
+	queryJSON, err := encodeEmbeddingJSON(request.Query)
+	if err != nil {
+		return "", nil, err
+	}
+	query := fmt.Sprintf(`
+		select m.external_id, m.metadata_json, v.distance
+		from %s as v
+		join %s as m on m.rowid = v.rowid
+		where embedding match ?
+	`, quoteSQLiteIdentifier(store.VectorTableName), quoteSQLiteIdentifier(store.MetadataTable))
+	args := []any{queryJSON}
+	if strings.TrimSpace(request.ExternalID) != "" {
+		query += " and m.external_id <> ?\n"
+		args = append(args, request.ExternalID)
+	}
+	query += "\t\torder by distance\n\t\tlimit ?\n\t"
+	args = append(args, request.Limit)
+	return query, args, nil
 }
 
 func (service *sqliteVecService) searchFallback(store profileStoreDefinition, request SearchRequest, metric DistanceMetric) ([]SearchResult, error) {

--- a/internal/vectorstore/sqlite_vec_service_test.go
+++ b/internal/vectorstore/sqlite_vec_service_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Neneka448/gogoclaw/internal/config"
@@ -366,6 +367,54 @@ func TestSQLiteVecServiceSearchByThresholdNotStarted(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("SearchByThreshold() error = nil, want not-started error")
+	}
+}
+
+func TestBuildSQLiteVecSearchQueryExcludesExternalID(t *testing.T) {
+	query, args, err := buildSQLiteVecSearchQuery(profileStoreDefinition{
+		VectorTableName: "gogoclaw_vec_default_text_vectors",
+		MetadataTable:   "gogoclaw_vec_default_text_records",
+	}, SearchRequest{
+		Query:      []float32{1, 0, 0},
+		Limit:      5,
+		ExternalID: "alpha",
+	})
+	if err != nil {
+		t.Fatalf("buildSQLiteVecSearchQuery() error = %v", err)
+	}
+	if !strings.Contains(query, "and m.external_id <> ?") {
+		t.Fatalf("query = %q, want external_id exclusion clause", query)
+	}
+	if len(args) != 3 {
+		t.Fatalf("len(args) = %d, want 3", len(args))
+	}
+	if externalID, ok := args[1].(string); !ok || externalID != "alpha" {
+		t.Fatalf("args[1] = %#v, want alpha", args[1])
+	}
+	if limit, ok := args[2].(int); !ok || limit != 5 {
+		t.Fatalf("args[2] = %#v, want 5", args[2])
+	}
+}
+
+func TestBuildSQLiteVecSearchQueryWithoutExternalID(t *testing.T) {
+	query, args, err := buildSQLiteVecSearchQuery(profileStoreDefinition{
+		VectorTableName: "gogoclaw_vec_default_text_vectors",
+		MetadataTable:   "gogoclaw_vec_default_text_records",
+	}, SearchRequest{
+		Query: []float32{1, 0, 0},
+		Limit: 3,
+	})
+	if err != nil {
+		t.Fatalf("buildSQLiteVecSearchQuery() error = %v", err)
+	}
+	if strings.Contains(query, "external_id <>") {
+		t.Fatalf("query = %q, want no external_id exclusion clause", query)
+	}
+	if len(args) != 2 {
+		t.Fatalf("len(args) = %d, want 2", len(args))
+	}
+	if limit, ok := args[1].(int); !ok || limit != 3 {
+		t.Fatalf("args[1] = %#v, want 3", args[1])
 	}
 }
 


### PR DESCRIPTION
- exclude external ids in sqlite-vec SQL to match fallback behavior
- add focused tests for sqlite-vec query construction